### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build_bioconductor_docker.yml
+++ b/.github/workflows/build_bioconductor_docker.yml
@@ -18,7 +18,7 @@ jobs:
 
     # Build Tools
     - name: Build and Publish
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: sjwidmay/lcGBS_HR
         username: ${{ secrets.SJW_DOCKER_USER }}

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -20,7 +20,7 @@ jobs:
 
     # Build Tools
     - name: Build and Publish
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: sjwidmay/DO4WC_HR
         username: ${{ secrets.SJW_DOCKER_USER }}

--- a/.github/workflows/build_lcGBS_HR_docker.yml
+++ b/.github/workflows/build_lcGBS_HR_docker.yml
@@ -18,7 +18,7 @@ jobs:
 
     # Build Tools
     - name: Build and Publish
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: sjwidmay/lcGBS_HR
         username: ${{ secrets.SJW_DOCKER_USER }}

--- a/.github/workflows/build_lcGBS_STITCH_docker.yml
+++ b/.github/workflows/build_lcGBS_STITCH_docker.yml
@@ -20,7 +20,7 @@ jobs:
 
     # Build Tools
     - name: Build and Publish
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: sjwidmay/lcGBS_HR
         username: ${{ secrets.SJW_DOCKER_USER }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore